### PR TITLE
fix activation and deactivation hook errors

### DIFF
--- a/includes/WPQuery.php
+++ b/includes/WPQuery.php
@@ -26,7 +26,7 @@ class WPQueryPlugin
         $this->table = $this->db->prefix . $this->config->table;
 
         register_activation_hook($file, array($this, 'install'));
-        register_deactivation_hook($file, array($this, 'uninstall'));
+        register_uninstall_hook($file, array($this, 'uninstall'));
 
         $this->addMenu();
         $this->registerRoutes();

--- a/includes/WPQuery.php
+++ b/includes/WPQuery.php
@@ -10,13 +10,23 @@ class WPQueryPlugin
     private $config;
     private $cache = [];
 
-    public function __construct()
+
+    /**
+     * Inits the plugin. Called from the main plugin file. 
+     * 
+     * @param string file path to main plugin file (index.php)
+     * @return void
+     */
+    public function __construct($file)
     {
         global $wpdb;
         $this->db = $wpdb;
         
         $this->config = (object) require(WPQUERY_ROOT . 'config.php');
         $this->table = $this->db->prefix . $this->config->table;
+
+        register_activation_hook($file, array($this, 'install'));
+        register_activation_hook($file, array($this, 'uninstall'));
 
         $this->addMenu();
         $this->registerRoutes();

--- a/includes/WPQuery.php
+++ b/includes/WPQuery.php
@@ -26,7 +26,7 @@ class WPQueryPlugin
         $this->table = $this->db->prefix . $this->config->table;
 
         register_activation_hook($file, array($this, 'install'));
-        register_activation_hook($file, array($this, 'uninstall'));
+        register_deactivation_hook($file, array($this, 'uninstall'));
 
         $this->addMenu();
         $this->registerRoutes();

--- a/index.php
+++ b/index.php
@@ -22,7 +22,4 @@ defined('ABSPATH') or die;
 define('WPQUERY_ROOT', plugin_dir_path(__FILE__) . 'includes/');
 
 require_once(WPQUERY_ROOT . 'WPQuery.php');
-$wpQuery = new WPQueryPlugin();
-
-register_activation_hook(__FILE__, [$wpQuery, 'install']);
-register_uninstall_hook(__FILE__, [$wpQuery, 'uninstall']);
+$wpQuery = new WPQueryPlugin(__FILE__);


### PR DESCRIPTION
Fixes this error upon activation
`register_uninstall_hook was called incorrectly. Only a static class method or function can be used in an uninstall hook.`
This method of doing things seems to be working. See https://wordpress.stackexchange.com/a/269023