### PR TITLE
use WP Option API

### DIFF
--- a/includes/config.php
+++ b/includes/config.php
@@ -3,9 +3,6 @@
 defined('ABSPATH') or die;
 
 return [
-  'table' => 'wpquery',
-  'key' => 'setting',
-  'value' => 'value',
   'secret' => 'wpquery_apikey',
   'namespace' => 'wpquery/v1',
   'routes'=> [


### PR DESCRIPTION
This switches to using the WordPress [Options API](https://codex.wordpress.org/Options_API) which is better for things that does not require much storage in the database.

The nice thing about the options API is that you can use arrays, objects, etc… and they will be serialized automagically. 